### PR TITLE
fix: optimize isPublicRepoWithMeta by using getRepoName instead of ca…

### DIFF
--- a/src/helpers/get-github-repo-info.ts
+++ b/src/helpers/get-github-repo-info.ts
@@ -55,8 +55,5 @@ export async function isPublicRepoWithMeta() {
   if (platform === 'unknown') {
     return false;
   }
-  return (
-    (await isPublicRepo()) &&
-    ((await metaStore.has(platform, getRepoNameByUrl())) || (await metaStore.has(platform, getRepoNameByPage())))
-  );
+  return (await isPublicRepo()) && (await metaStore.has(platform, getRepoName()));
 }


### PR DESCRIPTION
…lling metaStore.has twice

## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #xxx

## Details
<!-- What did you do in this PR?  -->
optimize isPublicRepoWithMeta by using getRepoName instead of calling metaStore.has twice
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
